### PR TITLE
.gitignore: added tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Posters
 Trailers
 output
+tmp
 Session
 Sessions
 venv*


### PR DESCRIPTION
With the addition on of the tmp folder in commit b84149681ece063012bf9df9ececb0647694ce56, this commit adds this folder to .gitignore so you don't accidentally commit it